### PR TITLE
Add support for deserializing str

### DIFF
--- a/simd-json-derive-int/src/args.rs
+++ b/simd-json-derive-int/src/args.rs
@@ -20,6 +20,7 @@ impl Parse for FieldAttrs {
 
                     rename = Some(name.to_string().trim_matches('"').to_string());
                 }
+                "borrow" => (),
                 other => {
                     return Err(syn::Error::new(
                         attr.span(),

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -25,6 +25,21 @@ impl<'input> Deserialize<'input> for String {
     }
 }
 
+impl<'input> Deserialize<'input> for &'input str {
+    #[inline]
+    fn from_tape(tape: &mut Tape<'input>) -> simd_json::Result<Self>
+    where
+        Self: std::marker::Sized + 'input,
+    {
+        match tape.next() {
+            Some(simd_json::Node::String(s)) => Ok(s),
+            _ => Err(simd_json::Error::generic(
+                simd_json::ErrorType::ExpectedString,
+            )),
+        }
+    }
+}
+
 impl Serialize for str {
     #[inline]
     fn json_write<W>(&self, writer: &mut W) -> Result

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -69,3 +69,21 @@ fn named_lifetime() {
     println!("{}", b.json_string().unwrap());
     assert_eq!(r#"{"f1":"snot","f2":"badger"}"#, b.json_string().unwrap())
 }
+
+#[test]
+fn borrowed() {
+    #[derive(simd_json_derive::Serialize, simd_json_derive::Deserialize, PartialEq, Debug)]
+    struct SIMDExample<'sin> {
+        id: u64,
+        #[serde(borrow)]
+        id_str: &'sin str,
+    };
+    let mut s = r#"{"id":23,"id_str":"42"}"#.to_string();
+    assert_eq!(
+        SIMDExample {
+            id: 23,
+            id_str: "42"
+        },
+        SIMDExample::from_str(s.as_mut_str()).unwrap()
+    );
+}


### PR DESCRIPTION
We can now deserialize `str` as part of the derive, also `#[serde(borrow)]` no longer fails (and is ignored)