### PR TITLE
Updates for Rust 1.64.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,33 @@
+name: Tests - Nightly
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  build-nightly:
+    strategy:
+      matrix:
+        rustflags:
+          - '-C target-cpu=native'
+        features:
+          - ''
+          - '--features 128bit'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - name: Build
+      env:
+        RUSTFLAGS: ${{ matrix.rustflags }}
+      run: cargo build ${{ matrix.features }}
+    - name: Run tests
+      env:
+        RUSTFLAGS: ${{ matrix.rustflags }}
+      run: cargo test ${{ matrix.features }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,0 +1,63 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profiles: minimal
+          override: true
+          components: rustfmt,clippy
+      - name: Validate cargo format
+        run: cargo fmt -- --check
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy action to produce annotations
+        uses: actions-rs/clippy-check@v1
+        if: steps.check_permissions.outputs.has-permission
+        env:
+          RUSTFLAGS: "-C target-cpu=native"
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all
+      - name: Run clippy manually without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        env:
+          RUSTFLAGS: "-C target-cpu=native"
+        run: cargo clippy --all
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable        
+          profile: minimal
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run codecov
+        env:
+          RUSTFLAGS: "-C target-cpu=native"
+        run: cargo llvm-cov --lcov --output-path lcov.txt 
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./lcov.txt # optional
+          flags: ${{ env.flags }} # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        rustflags:
+          - '-C target-cpu=native'
+        features:
+          - ''
+          - '--features 128bit'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Build
+      env:
+        RUSTFLAGS: ${{ matrix.rustflags }}
+      run: cargo build ${{ matrix.features }}
+    - name: Run tests
+      env:
+        RUSTFLAGS: ${{ matrix.rustflags }}
+      run: cargo test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,10 @@ allow-non-simd = [
 
 [package.metadata.docs.rs]
 features = ["allow-non-simd"]
+
+[[bench]]
+name = "value"
+harness = false
+
+[[example]]
+name = "enum1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/simd-json-derive"
 readme = "README.md"
 homepage = "https://docs.rs/simd-json-derive"
 repository = "https://github.com/simd-lite/simd-json-derive/"
+rust-version = "1.59"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,10 @@ serde = "1"
 default = ["impl-chrono"]
 impl-chrono = ["chrono"]
 128bit = ["simd-json-derive-int/128bit", "simd-json/128bit"]
+allow-non-simd = [
+    "simd-json-derive-int/allow-non-simd",
+    "simd-json/allow-non-simd",
+]
+
+[package.metadata.docs.rs]
+features = ["allow-non-simd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,5 @@ allow-non-simd = [
 [package.metadata.docs.rs]
 features = ["allow-non-simd"]
 
-[[bench]]
-name = "value"
-harness = false
-
 [[example]]
 name = "enum1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # simd-json-derive
 
 [![Latest version](https://img.shields.io/crates/v/simd-json-derive.svg)](https://crates.io/crates/simd-json-derive)
+[![documentation](https://img.shields.io/docsrs/simd-json-derive)](https://docs.rs/simd-json-derive)
 ![License](https://img.shields.io/crates/l/simd-json-derive.svg)
+
 
 Derives for high performance JSON serialisation and deserialisation.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
-Derives for high performance JSON serialisation (and eventually deserialisation).
+# simd-json-derive
 
-Attributres are supported for both `#[simd_json(...)]` and for compatibilty also for `#[serde(...)]` and follow the same nameing conventions as serde.
+[![Latest version](https://img.shields.io/crates/v/simd-json-derive.svg)](https://crates.io/crates/simd-json-derive)
+![License](https://img.shields.io/crates/l/simd-json-derive.svg)
+
+Derives for high performance JSON serialisation and deserialisation.
+
+## Usage
+
+```rust
+
+#[derive(Serialize, Deserialize, Debug)]
+#[simd_json(deny_unknown_fields, rename_all = "camelCase")]
+struct MyStruct {
+    first_field: String,
+    #[simd_json(rename = "foo")]
+    second_field: Option<usize>
+}
+
+fn main -> Result<(), simd_json::Error> {
+    let my_struct = MyStruct {
+        first_field: "i am first".to_string(),
+        second_field: None
+    }
+    println!("Before: {my_struct:?}");
+    let mut json_string = my_struct.json_string()?;
+    let deserialized = MyStruct::from_str(json_string.as_mut_str())?;
+    println!("After: {deserialized:?}");
+}
+```
+
+## Supported Attributes
+
+Attributres are supported for both `#[simd_json(...)]` and for compatibilty also for `#[serde(...)]` and follow the same naming conventions as serde.
 
 For fields:
 
@@ -8,4 +39,5 @@ For fields:
 
 For structs:
 
-* `rename_all = "camelCase"` - renames all (not otherwise renamed) based on the rule, `camelCase` is currently supportd
+* `rename_all = "camelCase"` - renames all (not otherwise renamed) based on the rule, `camelCase` is currently supported
+* `deny_unknown_fields` - Errors if unknown fields are encountered

--- a/examples/enum1.rs
+++ b/examples/enum1.rs
@@ -1,4 +1,6 @@
-#[derive(simd_json_derive::Deserialize)]
+use simd_json_derive::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
 pub enum StoredVariants {
     YesNo(bool),
     Small(u8, i8),
@@ -6,4 +8,11 @@ pub enum StoredVariants {
     Stringy(String),
 }
 
-fn main() {}
+fn main() {
+    let x = StoredVariants::Signy(-1);
+    let mut serialized = x.json_string().expect("serialization shouldnt fail :(");
+    let deserialized = StoredVariants::from_str(serialized.as_mut_str())
+        .expect("serialized stuff should be deserializable");
+    println!("Serialized: {x:?}");
+    println!("Deserialized: {deserialized:?}");
+}

--- a/simd-json-derive-int/Cargo.toml
+++ b/simd-json-derive-int/Cargo.toml
@@ -15,7 +15,9 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["visit", "extra-traits"] }
-simd-json = { version = "0.6", features = ["allow-non-simd"] }
+simd-json = "0.6"
 
 [features]
+default = ["allow-non-simd"]
 128bit = ["simd-json/128bit"]
+allow-non-simd = ["simd-json/allow-non-simd"]

--- a/simd-json-derive-int/src/deserialize.rs
+++ b/simd-json-derive-int/src/deserialize.rs
@@ -23,9 +23,10 @@ fn derive_named_struct(
     let mut options = Vec::new();
     let mut ids = Vec::new();
     let mut opt_ids = Vec::new();
-    let mut id: u64 = 1;
+    let mut id: u64 = 0;
     let mut all: u64 = 0;
     let mut all_needed: u64 = 0;
+    let deny_unknown_fields: bool = attrs.deny_unknown_fields();
     let params = &generics.params;
     let (all_generics, derive_lt) = match params.first() {
         None => (quote! { <'input> }, quote! { 'input }),
@@ -44,8 +45,9 @@ fn derive_named_struct(
             }
         }
 
-        if let Some((name, ident)) =
-            name(&attrs, f).and_then(|name| Some((name, f.ident.as_ref()?.clone())))
+        if let Some((name, ident)) = attrs
+            .name(f)
+            .and_then(|name| Some((name, f.ident.as_ref()?.clone())))
         {
             let name = name.trim_matches(':').trim_matches('"').to_string();
             let bit = 1 << id;
@@ -103,10 +105,13 @@ fn derive_named_struct(
 
                                 },
                                 )*
-                                _ => {
-                                    // FIXME: this should be togglable
-                                    __err = Some(::simd_json::Error::generic(::simd_json::ErrorType::ExpectedMap));
+                                __unknown_field if #deny_unknown_fields => {
+                                    use ::serde::de::Error;
+                                    __err = Some(::simd_json::Error::unknown_field(__unknown_field, &[ #(#keys),* ]));
                                     break
+                                }
+                                _ => {
+                                    // ignore unknown field
                                 }
                             }
                         },
@@ -116,7 +121,25 @@ fn derive_named_struct(
                     }
                 }
                 if (__seen & #all_needed) != #all_needed && __err.is_none() {
-                    __err = Some(::simd_json::Error::generic(::simd_json::ErrorType::ExpectedMap))
+
+                    use ::serde::de::Error;
+                    // extract the missing field names
+                    let mut __missing_field_ids: u64 = (__seen ^ #all_needed);
+                    let mut __missing_fields: Vec<String> = Vec::with_capacity(__missing_field_ids.count_ones() as usize);
+                    while __missing_field_ids != 0 {
+                        #(
+                            if #ids & __missing_field_ids == #ids {
+                                __missing_fields.push(#keys.to_string());
+                                __missing_field_ids ^= #ids; // clear out the bit
+                            }
+                        )*
+                    }
+                    let __msg = if __missing_fields.len() == 1 {
+                        "missing field"
+                    } else {
+                        "missing fields"
+                    };
+                    __err = Some(::simd_json::Error::custom(format!("{}: `{}`", __msg, __missing_fields.join("`, `"))));
                 }
 
                 if let Some(e) = __err {

--- a/simd-json-derive-int/src/deserialize.rs
+++ b/simd-json-derive-int/src/deserialize.rs
@@ -24,7 +24,6 @@ fn derive_named_struct(
     let mut ids = Vec::new();
     let mut opt_ids = Vec::new();
     let mut id: u64 = 0;
-    let mut all: u64 = 0;
     let mut all_needed: u64 = 0;
     let deny_unknown_fields: bool = attrs.deny_unknown_fields();
     let params = &generics.params;
@@ -52,7 +51,6 @@ fn derive_named_struct(
             let name = name.trim_matches(':').trim_matches('"').to_string();
             let bit = 1 << id;
             id += 1;
-            all = all | bit;
             if is_option {
                 options.push(ident.clone());
                 opt_ids.push(bit);
@@ -151,6 +149,7 @@ fn derive_named_struct(
                         } = __res;
                         #(
                         if #ids & __seen == 0 {
+                            #[allow(clippy::forget_ref)]
                             ::std::mem::forget(#values);
                         };
                         )*

--- a/simd-json-derive-int/src/serialize.rs
+++ b/simd-json-derive-int/src/serialize.rs
@@ -72,8 +72,9 @@ fn derive_named_struct(
     let mut values = Vec::new();
 
     for f in &fields {
-        if let Some((name, ident)) =
-            name(&attrs, f).and_then(|name| Some((name, f.ident.as_ref()?.clone())))
+        if let Some((name, ident)) = attrs
+            .name(f)
+            .and_then(|name| Some((name, f.ident.as_ref()?.clone())))
         {
             keys.push(name);
             values.push(ident);

--- a/simd-json-derive-int/src/serialize.rs
+++ b/simd-json-derive-int/src/serialize.rs
@@ -39,19 +39,11 @@ fn derive_unnamed_struct(
                 fn json_write<W>(&self, writer: &mut W) -> std::io::Result<()>
                 where
                     W: std::io::Write {
-                        if let Err(e) = writer.write_all(b"[") {
-                            return Err(e)
-                        }
-                            if let Err(e) = self.0.json_write(writer) {
-                                return Err(e)
-                            }
+                        writer.write_all(b"[")?;
+                        self.0.json_write(writer)?;
                         #(
-                            if let Err(e) = writer.write_all(b",") {
-                                return Err(e)
-                            };
-                            if let Err(e) = self.#keys.json_write(writer) {
-                                return Err(e)
-                            };
+                            writer.write_all(b",")?;
+                            self.#keys.json_write(writer)?;
                         )*
                         writer.write_all(b"]")
                     }
@@ -95,12 +87,8 @@ fn derive_named_struct(
             where
                 W: std::io::Write {
                     #(
-                        if let Err(e) = writer.write_all(#keys.as_bytes()) {
-                            return Err(e);
-                        }
-                        if let Err(e) = self.#values.json_write(writer) {
-                            return Err(e);
-                        }
+                        writer.write_all(#keys.as_bytes())?;
+                        self.#values.json_write(writer)?;
                     )*
                     writer.write_all(b"}")
                 }
@@ -172,12 +160,8 @@ fn derive_enum(ident: Ident, data: DataEnum, generics: Generics) -> TokenStream 
     let unnamed1 = quote! {
         #(
             #ident::#unnamed1_idents(v) => {
-                if let Err(e) = writer.write_all(#unnamed1_keys.as_bytes()) {
-                    return Err(e);
-                };
-                if let Err(e) = v.json_write(writer) {
-                    return Err(e);
-                };
+                writer.write_all(#unnamed1_keys.as_bytes())?;
+                v.json_write(writer)?;
                 writer.write_all(b"}")
             }
         ),*
@@ -213,16 +197,10 @@ fn derive_enum(ident: Ident, data: DataEnum, generics: Generics) -> TokenStream 
     let unnamed_vecs = unnamed_var_names.iter().map(|vs| {
         let (first, rest) = vs.split_first().expect("zero unnamed vars");
         quote! {
-            if let Err(e) = #first.json_write(writer) {
-                return Err(e);
-            };
+            #first.json_write(writer)?;
             #(
-                if let Err(e) = writer.write_all(b",") {
-                    return Err(e);
-                };
-                if let Err(e) = #rest.json_write(writer) {
-                    return Err(e);
-                };
+                writer.write_all(b",")?;
+                #rest.json_write(writer)?;
             )*
         }
     });
@@ -233,9 +211,7 @@ fn derive_enum(ident: Ident, data: DataEnum, generics: Generics) -> TokenStream 
         #(
             #ident::#unnamed_idents(#unnamed_vars) =>
             {
-                if let Err(e) = writer.write_all(#unnamed_keys.as_bytes()) {
-                    return Err(e);
-                };
+                writer.write_all(#unnamed_keys.as_bytes())?;
                 #unnamed_vecs
                 writer.write_all(b"]}")
             }
@@ -271,19 +247,11 @@ fn derive_enum(ident: Ident, data: DataEnum, generics: Generics) -> TokenStream 
 
         named_bodies.push(quote! {
             #ident::#named_ident{#(#fields),*} => {
-                if let Err(e) = writer.write_all(#start.as_bytes()) {
-                    return Err(e);
-                };
-                if let Err(e) = #first.json_write(writer) {
-                    return Err(e);
-                };
+                writer.write_all(#start.as_bytes())?;
+                #first.json_write(writer)?;
                 #(
-                    if let Err(e) = writer.write_all(#rest_keys.as_bytes()) {
-                        return Err(e);
-                    };
-                    if let Err(e) = #rest.json_write(writer) {
-                        return Err(e);
-                    };
+                    writer.write_all(#rest_keys.as_bytes())?;
+                    #rest.json_write(writer)?;
 
                 )*
                 writer.write_all(b"}}")

--- a/src/impls/array.rs
+++ b/src/impls/array.rs
@@ -62,9 +62,9 @@ mod test {
     #[test]
     fn slice() {
         let s: [u8; 0] = [];
-        assert_eq!((&s).json_string().unwrap(), "[]");
-        assert_eq!((&[1]).json_string().unwrap(), "[1]");
-        assert_eq!((&[1, 2]).json_string().unwrap(), "[1,2]");
-        assert_eq!((&[1, 2, 3]).json_string().unwrap(), "[1,2,3]");
+        assert_eq!(s.json_string().unwrap(), "[]");
+        assert_eq!([1].json_string().unwrap(), "[1]");
+        assert_eq!([1, 2].json_string().unwrap(), "[1,2]");
+        assert_eq!([1, 2, 3].json_string().unwrap(), "[1,2,3]");
     }
 }

--- a/src/impls/array.rs
+++ b/src/impls/array.rs
@@ -25,19 +25,11 @@ macro_rules! array_impls {
                 {
                     let mut i = self.iter();
                     if let Some(first) = i.next() {
-                        if let Err(e) = writer.write_all(b"["){
-                            return Err(e);
-                        };
-                        if let Err(e) = first.json_write(writer){
-                            return Err(e);
-                        };
+                        writer.write_all(b"[")?;
+                        first.json_write(writer)?;
                         for e in i {
-                            if let Err(e) = writer.write_all(b","){
-                                return Err(e);
-                            };
-                            if let Err(e) = e.json_write(writer){
-                                return Err(e);
-                            };
+                            writer.write_all(b",")?;
+                            e.json_write(writer)?;
                         }
                         writer.write_all(b"]")
                     } else {

--- a/src/impls/collections.rs
+++ b/src/impls/collections.rs
@@ -15,19 +15,11 @@ macro_rules! vec_like {
             {
                 let mut i = self.iter();
                 if let Some(first) = i.next() {
-                    if let Err(e) = writer.write_all(b"[") {
-                        return Err(e);
-                    };
-                    if let Err(e) = first.json_write(writer) {
-                        return Err(e);
-                    };
+                    writer.write_all(b"[")?;
+                    first.json_write(writer)?;
                     for e in i {
-                        if let Err(e) = writer.write_all(b",") {
-                            return Err(e);
-                        };
-                        if let Err(e) = e.json_write(writer) {
-                            return Err(e);
-                        };
+                        writer.write_all(b",")?;
+                        e.json_write(writer)?;
                     }
                     writer.write_all(b"]")
                 } else {
@@ -168,19 +160,11 @@ where
     {
         let mut i = self.iter();
         if let Some(first) = i.next() {
-            if let Err(e) = writer.write_all(b"[") {
-                return Err(e);
-            };
-            if let Err(e) = first.json_write(writer) {
-                return Err(e);
-            };
+            writer.write_all(b"[")?;
+            first.json_write(writer)?;
             for e in i {
-                if let Err(e) = writer.write_all(b",") {
-                    return Err(e);
-                };
-                if let Err(e) = e.json_write(writer) {
-                    return Err(e);
-                };
+                writer.write_all(b",")?;
+                e.json_write(writer)?;
             }
             writer.write_all(b"]")
         } else {
@@ -225,31 +209,15 @@ where
     {
         let mut i = self.iter();
         if let Some((k, v)) = i.next() {
-            if let Err(e) = writer.write_all(b"{") {
-                return Err(e);
-            };
-            if let Err(e) = k.json_write(writer) {
-                return Err(e);
-            };
-            if let Err(e) = writer.write_all(b":") {
-                return Err(e);
-            };
-            if let Err(e) = v.json_write(writer) {
-                return Err(e);
-            };
+            writer.write_all(b"{")?;
+            k.json_write(writer)?;
+            writer.write_all(b":")?;
+            v.json_write(writer)?;
             for (k, v) in i {
-                if let Err(e) = writer.write_all(b",") {
-                    return Err(e);
-                };
-                if let Err(e) = k.json_write(writer) {
-                    return Err(e);
-                };
-                if let Err(e) = writer.write_all(b":") {
-                    return Err(e);
-                };
-                if let Err(e) = v.json_write(writer) {
-                    return Err(e);
-                };
+                writer.write_all(b",")?;
+                k.json_write(writer)?;
+                writer.write_all(b":")?;
+                v.json_write(writer)?;
             }
             writer.write_all(b"}")
         } else {
@@ -294,31 +262,15 @@ where
     {
         let mut i = self.iter();
         if let Some((k, v)) = i.next() {
-            if let Err(e) = writer.write_all(b"{") {
-                return Err(e);
-            };
-            if let Err(e) = k.json_write(writer) {
-                return Err(e);
-            };
-            if let Err(e) = writer.write_all(b":") {
-                return Err(e);
-            };
-            if let Err(e) = v.json_write(writer) {
-                return Err(e);
-            };
+            writer.write_all(b"{")?;
+            k.json_write(writer)?;
+            writer.write_all(b":")?;
+            v.json_write(writer)?;
             for (k, v) in i {
-                if let Err(e) = writer.write_all(b",") {
-                    return Err(e);
-                };
-                if let Err(e) = k.json_write(writer) {
-                    return Err(e);
-                };
-                if let Err(e) = writer.write_all(b":") {
-                    return Err(e);
-                };
-                if let Err(e) = v.json_write(writer) {
-                    return Err(e);
-                };
+                writer.write_all(b",")?;
+                k.json_write(writer)?;
+                writer.write_all(b":")?;
+                v.json_write(writer)?;
             }
             writer.write_all(b"}")
         } else {
@@ -358,18 +310,10 @@ where
     where
         W: Write,
     {
-        if let Err(e) = writer.write_all(b"{\"start\":") {
-            return Err(e);
-        };
-        if let Err(e) = self.start.json_write(writer) {
-            return Err(e);
-        }
-        if let Err(e) = writer.write_all(b",\"end\":") {
-            return Err(e);
-        };
-        if let Err(e) = self.end.json_write(writer) {
-            return Err(e);
-        }
+        writer.write_all(b"{\"start\":")?;
+        self.start.json_write(writer)?;
+        writer.write_all(b",\"end\":")?;
+        self.end.json_write(writer)?;
         writer.write_all(b"}")
     }
 }

--- a/src/impls/primitives.rs
+++ b/src/impls/primitives.rs
@@ -149,7 +149,7 @@ impl<'input> Deserialize<'input> for f32 {
             #[cfg(feature = "128bit")]
             Some(simd_json::Node::Static(simd_json::StaticNode::I128(i))) => Ok(i as f32),
             _ => Err(simd_json::Error::generic(
-                simd_json::ErrorType::ExpectedString,
+                simd_json::ErrorType::ExpectedFloat,
             )),
         }
     }

--- a/src/impls/tpl.rs
+++ b/src/impls/tpl.rs
@@ -40,18 +40,12 @@ macro_rules! tuple_impls {
                 where
                     W: Write,
                 {
-                    if let Err(e) = writer.write_all(b"["){
-                        return Err(e);
-                    };
+                    writer.write_all(b"[")?;
                     $(
                         if $n != 0 {
-                            if let Err(e) = writer.write_all(b","){
-                                return Err(e);
-                            };
+                            writer.write_all(b",")?;
                         }
-                        if let Err(e) = self.$n.json_write(writer){
-                            return Err(e);
-                        };
+                        self.$n.json_write(writer)?;
                     )+
                     writer.write_all(b"]")
                 }

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -2,13 +2,13 @@ use simd_json_derive::{Deserialize, Serialize};
 
 #[test]
 fn rename() {
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Bla<'f3> {
         #[serde(rename = "f3")]
         f1: u8,
         #[simd_json(rename = "f4")]
         f2: String,
-        #[serde(borrow)]
+        #[serde(borrow, rename = "f1")]
         f3: &'f3 str,
         f5: u8,
     }
@@ -19,11 +19,13 @@ fn rename() {
         f3: "snot",
         f5: 8,
     };
-    println!("{}", b.json_string().unwrap());
-    assert_eq!(
-        r#"{"f3":1,"f4":"snot","f3":"snot","f5":8}"#,
-        b.json_string().unwrap()
-    )
+    let mut serialized = b.json_string().unwrap();
+    println!("{}", &serialized);
+
+    assert_eq!(r#"{"f3":1,"f4":"snot","f1":"snot","f5":8}"#, serialized);
+    let b1 = Bla::from_str(&mut serialized).expect("Expected serde roundtrip with rename to work");
+    println!("{:?}", &b1);
+    assert_eq!(b, b1);
 }
 
 #[test]

--- a/tests/deser.rs
+++ b/tests/deser.rs
@@ -93,7 +93,13 @@ fn opt() {
     assert!(Bla::from_str(s.as_mut_str()).is_err());
 
     let mut s = String::from(r#"{"name":"snot", "logo": "badger", "snot":42}"#);
-    assert!(Bla::from_str(s.as_mut_str()).is_err());
+    assert_eq!(
+        Bla {
+            name: MyString("snot".to_string()),
+            logo: Some("badger".to_string())
+        },
+        Bla::from_str(s.as_mut_str()).expect("Didn't ignore unknown field 'snot'")
+    );
 }
 #[test]
 fn event() {
@@ -134,36 +140,3 @@ fn enum_ser() {
     let e = StoredVariants::from_str(s.as_mut_str()).unwrap();
     assert_eq!(StoredVariants::YesNo(true), e);
 }
-// #[test]
-// fn unnamed1_lifetime() {
-//     #[derive(Serialize)]
-//     struct BlaU1L<'a>(&'a str);
-//     let b = BlaU1L("snot");
-//     println!("{}", b.json_string().unwrap());
-//     assert_eq!(r#""snot""#, b.json_string().unwrap())
-// }
-
-// #[test]
-// fn unnamed2_lifetime() {
-//     #[derive(Serialize)]
-//     struct BlaU2L<'a, 'b>(&'a str, &'b str);
-//     let b = BlaU2L("hello", "world");
-//     println!("{}", b.json_string().unwrap());
-//     assert_eq!(r#"["hello","world"]"#, b.json_string().unwrap())
-// }
-
-// #[test]
-// fn named_lifetime() {
-//     #[derive(Serialize)]
-//     struct BlaN2L<'a, 'b> {
-//         f1: &'a str,
-//         f2: &'b str,
-//     };
-
-//     let b = BlaN2L {
-//         f1: "snot",
-//         f2: "badger",
-//     };
-//     println!("{}", b.json_string().unwrap());
-//     assert_eq!(r#"{"f1":"snot","f2":"badger"}"#, b.json_string().unwrap())
-// }

--- a/tests/deser.rs
+++ b/tests/deser.rs
@@ -124,7 +124,7 @@ fn event() {
 
 #[test]
 fn enum_ser() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
     pub enum StoredVariants {
         YesNo(bool),
         Small(u8, i8),

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -2,11 +2,20 @@ use simd_json_derive::Deserialize;
 
 #[test]
 fn opt() {
-    #[derive(Deserialize)]
+    #[derive(Deserialize, PartialEq, Debug)]
     #[serde(rename_all = "camelCase")]
     struct Ranme {
         logo_name: Option<String>,
         #[serde(rename = "Name")]
         name: String,
     }
+    let mut s = r#"{"Name": "snot", "logoName": "badger"}"#.to_string();
+    let de = Ranme::from_str(s.as_mut_str()).expect("expected serialize with rename to work");
+    assert_eq!(
+        Ranme {
+            logo_name: Some("badger".to_string()),
+            name: "snot".to_string()
+        },
+        de
+    );
 }

--- a/tests/simdjson.rs
+++ b/tests/simdjson.rs
@@ -1,0 +1,16 @@
+use simd_json_derive::{Deserialize, Serialize};
+
+#[test]
+fn owned_value() {
+    let input = r#"{"snot":["badger",true,false,12.5,null,{"inner":[{}]},[[]]]}"#.to_string();
+    let value = simd_json::owned::to_value(unsafe { input.clone().as_bytes_mut() })
+        .expect("Expected the literal to work");
+    let res = value.json_string();
+    assert!(res.is_ok());
+    let mut serialized = res.ok().unwrap();
+    assert_eq!(input, serialized);
+    let deserialized = simd_json::owned::Value::from_str(serialized.as_mut_str())
+        .expect("Expected serialized input to be deserialized ok");
+    println!("{}", deserialized);
+    assert_eq!(value, deserialized);
+}

--- a/tests/unknown_fields.rs
+++ b/tests/unknown_fields.rs
@@ -1,0 +1,51 @@
+use simd_json_derive::{Deserialize, Serialize};
+
+#[test]
+fn deny_unknown_fields() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[simd_json(deny_unknown_fields)]
+    struct Strict {
+        snot: String,
+        badger: f64,
+        opt: Option<bool>,
+    }
+
+    let mut s = r#"{"snot":"foo", "badger":0.5, "unknown": "bla"}"#.to_string();
+    let res = Strict::from_str(s.as_mut_str());
+    assert!(res.is_err());
+    let err = res.err().unwrap();
+    assert!(err
+        .to_string()
+        .contains("unknown field `unknown`, expected one of `snot`, `badger`, `opt`"));
+}
+
+#[test]
+fn missing_required_fields() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct SomeFields {
+        snot: (u16, u32),
+        badger: Option<String>,
+        something: Vec<i64>,
+    }
+
+    let mut s = r#"{}"#.to_string();
+    let res = SomeFields::from_str(s.as_mut_str());
+    assert!(res.is_err());
+    let err = res.err().unwrap();
+    assert!(
+        err.to_string()
+            .contains("missing fields: `snot`, `something`"),
+        "Err: {} was wrong",
+        err
+    );
+
+    s = r#"{"snot": [65535, 65536]}"#.to_string();
+    let res = SomeFields::from_str(s.as_mut_str());
+    assert!(res.is_err());
+    let err = res.err().unwrap();
+    assert!(
+        err.to_string().contains("missing field: `something`"),
+        "Err: {} was wrong",
+        err
+    );
+}


### PR DESCRIPTION
* Enable `deny_unknown_fields` struct attribute
* Improve some error messages
* Remove some `if let Err(e) = ... { return Err(e); }` constructs as they result in the same assembly (in release mode) as the `?` operator.