### PR TITLE
Add new release workflows

### DIFF
--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -1,0 +1,70 @@
+name: "Draft new release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      new-version:
+        type: choice
+        description: "Which version you'd like to release?"
+        options:
+        - major (_.X.X)
+        - minor (X._.X)
+        - patch (X.X._)
+        - rc (X.X.X-rc)
+        - release (removes rc)
+        required: true
+
+jobs:
+  draft-new-release:
+    name: "Draft a new release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Install cargo-edit
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-edit
+          version: latest
+      - name: Extracting version from input
+        run: |
+          VERSION=$(echo "${{github.event.inputs.new-version}}" | sed 's/ (.*)$//')
+          echo "VER=$VERSION" >> $GITHUB_ENV
+      - name: Bump new version in TOML files
+        run: |
+          OLD_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          echo "OLD=$OLD_VERSION" >> $GITHUB_ENV
+          cargo set-version -p simd-json-derive-int --manifest-path=./simd-json-derive-int/Cargo.toml --bump ${{ env.VER }}
+          cargo set-version -p simd-json-derive     --manifest-path=./Cargo.toml                      --bump ${{ env.VER }}
+          NEW_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          echo "NEW=$NEW_VERSION" >> $GITHUB_ENV   
+      - name: Create release branch
+        run: |
+          git checkout -b release/${{ env.NEW }}
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub actions"
+          git config user.email noreply@github.com
+      - name: Updating Changelog and Dockerfile
+        run: .github/scripts/Bump.sh ${{ env.OLD }} ${{ env.NEW }}
+      - run: cargo check
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+
+          git commit -sa -m "Prepare release ${{ env.NEW }}"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+      - name: Push new branch
+        run: git push origin release/${{ env.NEW }}
+
+      - name: Create pull request
+        run: |
+          gh pr create -B main --title "Release-v${{ env.NEW }}" --body "Yay release" --label "Release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,51 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+      - labeled
+jobs:
+  release:
+    name: Publish new release
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged && contains( github.event.pull_request.labels.*.name, 'Release')
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub actions"
+          git config user.email noreply@github.com
+      - name: Pushing tags
+        run: |
+          VER=$(echo v${{ env.RELEASE_VERSION }} | sed 's/.*rc.*/rc/')
+          echo "RC=$VER" >> $GITHUB_ENV
+          git tag -a -m "Release v${{ env.RELEASE_VERSION }}" "v${{ env.RELEASE_VERSION }}"
+          git push origin v${{ env.RELEASE_VERSION }}
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v1
+      - name: Create release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ env.RELEASE_VERSION }}
+          release_name: Release v${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: ${{env.RC == 'rc'}}
+          body: ${{ steps.extract-release-notes.outputs.release_notes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+      - name: Trigger publish crates workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Publish crates
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
taken from the tremor-runtime repo. Those are just too convenient...