### PR TITLE
Avoid detached head during crates publishing

### DIFF
--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -15,8 +15,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - name: cargo update
-        run: cargo update
+      - name: ensure we are not in detached-head state
+        run: git switch -c v${{ gihub.ref_name }}
       - name: Publish simd-json-derive-int to crates.io
         uses: katyo/publish-crates@v1
         with:
@@ -34,10 +34,10 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - name: cargo update
-        run: cargo update
+      - name: ensure we are not in detached-head state
+        run: git switch -c v${{ gihub.ref_name }}
       - name: Publish simd-json-derive to crates.io
         uses: katyo/publish-crates@v1
         with:
-          path: '.'
+          path: './Cargo.toml'
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -8,7 +8,7 @@ on:
 
 
 jobs:
-  clippy_check:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/simd-json-derive-int/Cargo.toml
+++ b/simd-json-derive-int/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Heinz N. Gies <heinz@licenser.net>"]
 edition = "2021"
 license = "Apache-2.0/MIT"
 description = "procmacros for simd-json-derive"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+documentation = "https://docs.rs/simd-json-derive-int"
+repository = "https://github.com/simd-lite/simd-json-derive"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This seems to be an issue for the github action we use for publishing crates