### PR TITLE
use uppercase for Result enum but allow decoding lowercase

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -70,12 +70,12 @@ where
     {
         match self {
             Ok(e) => {
-                writer.write_all(b"{\"ok\":")?;
+                writer.write_all(b"{\"Ok\":")?;
                 e.json_write(writer)?;
                 writer.write_all(b"}")
             }
             Err(e) => {
-                writer.write_all(b"{\"err\":")?;
+                writer.write_all(b"{\"Err\":")?;
                 e.json_write(writer)?;
                 writer.write_all(b"}")
             }
@@ -95,6 +95,8 @@ where
     {
         if let Some(simd_json::Node::Object(1, _)) = tape.next() {
             match tape.next() {
+                Some(simd_json::Node::String("Ok")) => Ok(Ok(TOk::from_tape(tape)?)),
+                Some(simd_json::Node::String("Err")) => Ok(Err(TErr::from_tape(tape)?)),
                 Some(simd_json::Node::String("ok")) => Ok(Ok(TOk::from_tape(tape)?)),
                 Some(simd_json::Node::String("err")) => Ok(Err(TErr::from_tape(tape)?)),
                 _ => Err(simd_json::Error::generic(simd_json::ErrorType::ExpectedMap)),

--- a/tests/deser.rs
+++ b/tests/deser.rs
@@ -141,19 +141,19 @@ fn enum_ser() {
     let e = StoredVariants::from_str(s.as_mut_str()).unwrap();
     assert_eq!(StoredVariants::YesNo(true), e);
 
-    let mut s = String::from(r#"{"Res":{"ok":42}}"#);
+    let mut s = String::from(r#"{"Res":{"Ok":42}}"#);
     let e = StoredVariants::from_str(s.as_mut_str()).unwrap();
     assert_eq!(StoredVariants::Res(Ok(42)), e);
 
-    let mut s = String::from(r#"{"Res":{"err":"snot"}}"#);
+    let mut s = String::from(r#"{"Res":{"Err":"snot"}}"#);
     let e = StoredVariants::from_str(s.as_mut_str()).unwrap();
     assert_eq!(StoredVariants::Res(Err(String::from("snot"))), e);
 
     let e = StoredVariants::Res(Ok(42)).json_string().unwrap();
-    assert_eq!(r#"{"Res":{"ok":42}}"#, e);
+    assert_eq!(r#"{"Res":{"Ok":42}}"#, e);
 
     let e = StoredVariants::Res(Err(String::from("snot")))
         .json_string()
         .unwrap();
-    assert_eq!(r#"{"Res":{"err":"snot"}}"#, e);
+    assert_eq!(r#"{"Res":{"Err":"snot"}}"#, e);
 }


### PR DESCRIPTION
use uppercase for Result enum but allow decoding lowercase

fixes #38 